### PR TITLE
build: 이미지 빌드시 python 3.11 사용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim AS builder
+FROM python:3.11-slim AS builder
 
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_IN_PROJECT=1 \


### PR DESCRIPTION
- StrEnum이 3.11부터 지원되어 버전 수정 필요